### PR TITLE
Allow passing in SERIAL_PORT_PATH

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import {buildUartApiDal} from './modules/api-dal-uart';
 let logger: ILogger = createLogger('server');
 
 // TODO: need to inject dal type into here...
-let apiDal: IApiDal = buildUartApiDal('/dev/ttyS0', 115200);
+let apiDal: IApiDal = buildUartApiDal(process.env.SERIAL_PORT_PATH || '/dev/ttyS0', 115200);
 
 
 logger.debug('Server is starting');


### PR DESCRIPTION
Overrides the default of `/dev/ttyS0`. Enables running on Mac with a USB<>TTL adapter (like https://www.amazon.com/gp/product/B00N2FPJ0Q) that gets exposed as `/dev/tty.usbserial-<id>`.

Example:
$ ls /dev/tty.usbserial*
/dev/tty.usbserial-1234
$ SERIAL_PORT_PATH=/dev/tty.usbserial-1234 npm start